### PR TITLE
docs: add some new plugins from `yazi-rs` org

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Each plugin info contains the installation instruction preferably using `ya pack
 <summary>
 <a href="https://gitee.com/DreamMaoMao/epub.yazi">epub.yazi</a> - Plugin for Yazi to preview epub file</a>.
 </summary>
-  
+
 ```bash
 # Linux
 git clone https://github.com/DreamMaoMao/epub.yazi.git ~/.config/yazi/plugins/epub.yazi
-````
+```
+
 </details>
 
 <details>
@@ -217,38 +218,41 @@ ya pack -a redbeardymcgee/yazi-plugins:fg
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi">jump-to-char.yazi</a> - Vim-like `f<char>`, jump to the next file whose name starts with `<char>`.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:jump-to-char
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/redbeardymcgee/yazi-plugins/tree/main/keyjump.yazi">keyjump.yazi</a> - A Yazi plugin that jumps to a file by typing a hint character, much like hop.nvim.
 </summary>
-  
+
 ```bash
 ya pack -a redbeardymcgee/yazi-plugins:keyjump
 # Only for Yazi v0.2.5 or lesser
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/dedukun/relative-motions.yazi">relative-motions.yazi</a> - A Yazi plugin based on vim motions.
 </summary>
-  
+
 ```bash
 ya pack -a dedukun/relative-motions
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://gitee.com/DreamMaoMao/searchjump.yazi">searchjump.yazi</a> - A Yazi plugin which the behavior consistent with flash.nvim in Neovim, allow search str to generate lable to jump.support chinese pinyin search,regular expression search.
 </summary>
-  
+
 ```bash
 # Linux
 git clone https://gitee.com/DreamMaoMao/searchjump.yazi.git ~/.config/yazi/plugins/searchjump.yazi
@@ -258,12 +262,14 @@ git clone https://gitee.com/DreamMaoMao/searchjump.yazi.git ~/.config/yazi/plugi
 if (!(Test-Path $env:APPDATA\yazi\config\plugins\)) {mkdir $env:APPDATA\yazi\config\plugins\}
 git clone https://gitee.com/DreamMaoMao/searchjump.yazi.git $env:APPDATA\yazi\config\plugins\searchjump.yazi
 
-````
+```
+
 Note, the older version for this plugin, by same author, which works for yazi version >=0.3.0, can be installed with:
+
 ```bash
 # Visit: https://github.com/redbeardymcgee/yazi-plugins/tree/main/searchjump.yazi
 ya pack -a redbeardymcgee/yazi-plugins:searchjump
-````
+```
 
 </details>
 
@@ -273,7 +279,7 @@ ya pack -a redbeardymcgee/yazi-plugins:searchjump
 <summary>
 <a href="https://gitee.com/DreamMaoMao/bookmarks.yazi">DreamMaoMao/bookmarks.yazi</a> - A Yazi plugin that Supports persistent bookmark management.No bookmarks are lost after you close yazi.
 </summary>
-  
+
 ```bash
 # Linux/macOS
 git clone https://gitee.com/DreamMaoMao/bookmarks.yazi.git ~/.config/yazi/plugins/bookmarks.yazi
@@ -282,7 +288,8 @@ git clone https://gitee.com/DreamMaoMao/bookmarks.yazi.git ~/.config/yazi/plugin
 
 git clone https://gitee.com/DreamMaoMao/bookmarks.yazi.git $env:APPDATA\yazi\config\plugins\bookmarks.yazi
 
-````
+```
+
 </details>
 
 <details>
@@ -292,7 +299,7 @@ git clone https://gitee.com/DreamMaoMao/bookmarks.yazi.git $env:APPDATA\yazi\con
 
 ```bash
 ya pack -a dedukun/bookmarks
-````
+```
 
 </details>
 
@@ -300,30 +307,33 @@ ya pack -a dedukun/bookmarks
 <summary>
 <a href="https://github.com/redbeardymcgee/yazi-plugins/tree/main/bookmarks-persistence.yazi">bookmarks-persistence.yazi</a> - A Yazi plugin that supports persistent bookmark management. No bookmarks are lost after you close yazi.
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/MasouShizuka/projects.yazi">projects.yazi</a> - A Yazi plugin that adds the functionality to save and load projects.
 </summary>
-  
+
 ```bash
 ya pack -a MasouShizuka/projects
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/h-hg/yamb.yazi">yamb.yazi</a> - Yet another bookmarks plugin. It supports persistence, jumping by a key, and jumping by <a href="https://github.com/junegunn/fzf">fzf</a>.
 </summary>
-  
+
 ```bash
 ya pack -a h-hg/yamb
 ```
+
 </details>
 
 ### File Actions
@@ -332,110 +342,121 @@ ya pack -a h-hg/yamb
 <summary>
 <a href="https://github.com/KKV9/archive.yazi">archive.yazi</a> - Compress selected or hovered files and directories to an archive. It currently supports various archive formats.
 </summary>
-  
+
 ```bash
 ya pack -a KKV9/archive
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/AnirudhG07/archivemount.yazi">archivemount.yazi</a> - Mounting and unmounting archives in yazi using <a href="https://github.com/cybernoid/archivemount">archivemount</a>.
 </summary>
-  
+
 ```bash
 ya pack -a AnirudhG07/archivemount
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/chmod.yazi">chmod.yazi</a> - Execute `chmod` on the selected files to change their mode.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:chmod
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/diff.yazi">diff.yazi</a> - Diff the selected file with the hovered file, create a living patch, and copy it to the clipboard.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:diff
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/BBOOXX/file-actions.yazi">file-actions.yazi</a> - A Yazi plugin that allows users to perform actions on selected files using custom scripts.
 </summary>
-  
+
 ```bash
 ya pack -a BBOOXX/file-actions
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Lil-Dank/lazygit.yazi">lazygit.yazi</a> - Manage Git directories with <a href="https://github.com/jesseduffield/lazygit">lazygit</a> through a quick shortcut.
 </summary>
-  
+
 ```bash
 ya pack -a Lil-Dank/lazygit
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Sonico98/mkdir.yazi">mkdir.yazi</a> - Create directories without typing a trailing slash.
 </summary>
-  
+
 ```bash
 ya pack -a Sonico98/mkdir
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/ndtoan96/ouch.yazi">ouch.yazi</a> - An <a href="https://github.com/ouch-org/ouch">ouch</a> plugin for Yazi, supporting preview and compression.
 </summary>
-  
+
 ```bash
 ya pack -a ndtoan96/ouch
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Ape/reflink.yazi">reflink.yazi</a> - Create reflinks to files.
 </summary>
-  
+
 ```bash
 ya pack -a Ape/reflink
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/GianniBYoung/rsync.yazi">rsync.yazi</a> - Simple rsyncing locally and remotely.
 </summary>
-  
+
 ```bash
 ya pack -a GianniBYoung/rsync
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/pirafrank/what-size.yazi">what-size.yazi</a> - Calculate the total size of the current selection or of the current working directory.
 </summary>
-  
+
 ```bash
 ya pack -a pirafrank/what-size
 ```
+
 </details>
 
 ### Filter Enhancements
@@ -444,10 +465,11 @@ ya pack -a pirafrank/what-size
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/smart-filter.yazi">smart-filter.yazi</a> - Makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:smart-filter
 ```
+
 </details>
 
 ### Enter Enhancements
@@ -456,20 +478,22 @@ ya pack -a yazi-rs/plugins:smart-filter
 <summary>
 <a href="https://github.com/Rolv-Apneseth/bypass.yazi">bypass.yazi</a> - Yazi plugin for skipping directories with only a single sub-directory.
 </summary>
-  
+
 ```bash
 ya pack -a Rolv-Apneseth/bypass
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/ourongxing/fast-enter.yazi">fast-enter.yazi</a> - Auto-decompress archives and enter them, or enter the deepest directory until it's not the only subdirectory.
 </summary>
-  
+
 ```bash
 ya pack -a ourongxing/fast-enter
 ```
+
 </details>
 
 ### General command enhancements
@@ -478,50 +502,54 @@ ya pack -a ourongxing/fast-enter
 <summary>
 <a href="https://github.com/hankertrix/augment-command.yazi">augment-command.yazi</a> - Enhances a few Yazi commands with better handling of the choice between selected items and the hovered item. It also auto-extracts archives and includes features like bidirectional skipping of directories with a single sub-directory, along with plugins from the <a href="/docs/tips">tips page</a> such as `smart-enter`, `smart-paste`, `parent-arrow`, and more.
 </summary>
-  
+
 ```bash
 ya pack -a hankertrix/augment-command
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/TD-Sky/sudo.yazi">sudo.yazi</a> - Call `sudo` in yazi.
 </summary>
-  
+
 ```bash
 ya pack -a TD-Sky/sudo
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/orhnk/system-clipboard.yazi">system-clipboard.yazi</a> - Cross-platform system clipboard support for yazi.
 </summary>
-  
+
 ```bash
 ya pack -a orhnk/system-clipboard
 ```
+
 </details>
 
 ### UI enhancements
 
 <details>
 <summary>
-<a href="https://gitee.com/DreamMaoMao/current-size.yazi">full-border.yazi</a> - Get current path size in header bar for yazi plugin/
+<a href="https://gitee.com/DreamMaoMao/current-size.yazi">current-size.yazi</a> - Get current path size in header bar for yazi plugin/
 </summary>
-  
+
 ```bash
 git clone https://gitee.com/DreamMaoMao/current-size.yazi.git ~/.config/yazi/plugins/current-size.yazi
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/full-border.yazi">full-border.yazi</a> - Add a full border to Yazi to make it look fancier.
 </summary>
-  
-```bash
+
+````bash
 ya pack -a yazi-rs/plugins:full-border
 ```/UI
 </details>
@@ -530,100 +558,139 @@ ya pack -a yazi-rs/plugins:full-border
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi">hide-preview.yazi</a> - Switch the preview pane between hidden and shown.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:hide-preview
+````
+
+</details>
+
+<details>
+<summary>
+<a href="https://github.com/yazi-rs/plugins/tree/main/mactag.yazi">mactag.yazi</a> - Bring macOS's awesome tagging feature to Yazi! The plugin it's only available for macOS just like the name says.
+</summary>
+
+```bash
+ya pack -a yazi-rs/plugins:mactag
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi">max-preview.yazi</a> - Maximize or restore the preview pane.
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/plugins:max-preview
 ```
+
+</details>
+
+<details>
+<summary>
+<a href="https://github.com/yazi-rs/plugins/tree/main/no-status.yazi">no-status.yazi</a> - Remove the status bar.
+</summary>
+
+```bash
+ya pack -a yazi-rs/plugins:no-status
+```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/saumyajyoti/omp.yazi">omp.yazi</a> - oh-my-posh prompt plugin for Yazi.
 </summary>
-  
+
 ```bash
 ya pack -a saumyajyoti/omp
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Ape/open-with-cmd.yazi">open-with-cmd.yazi</a> - Open files using a prompted command.
 </summary>
-  
+
 ```bash
 ya pack -a Ape/open-with-cmd
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Ape/simple-status.yazi">simple-status.yazi</a> - Minimalistic status line with useful file attribute information.
 </summary>
-  
+
 ```bash
 ya pack -a Ape/simple-status
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Rolv-Apneseth/starship.yazi">starship.yazi</a> - Starship prompt plugin for Yazi.
 </summary>
-  
+
 ```bash
 ya pack -a Rolv-Apneseth/starship
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/imsi32/yatline.yazi">yatline.yazi</a> - Plugin for customizing both header-line and status-line.
 </summary>
-  
+
 ```bash
 ya pack -a imsi32/yatline
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/llanosrocas/yaziline.yazi">yaziline.yazi</a> - Simple lualine-like status line.
 </summary>
-  
+
 ```bash
 ya pack -a llanosrocas/yaziline
 ```
+
 </details>
 
 ### Git Utils
 
 <details>
 <summary>
-<a href="https://gitee.com/DreamMaoMao/git.yazi">git.yazi</a> - git extension and message prompt plugin for Yazi.
+<a href="https://gitee.com/DreamMaoMao/git.yazi">DreamMaoMao/git.yazi</a> - git extension and message prompt plugin for Yazi.
 </summary>
-  
+
 ```bash
 # For Linux
 git clone https://gitee.com/DreamMaoMao/git.yazi.git ~/.config/yazi/plugins/git.yazi
 
 # For Windows
-
 git clone https://gitee.com/DreamMaoMao/git.yazi $env:APPDATA\yazi\config\plugins\git.yazi
+```
 
-````
 </details>
 
+<details>
+<summary>
+<a href="https://github.com/yazi-rs/plugins/tree/main/git.yazi">yazi-rs/git.yazi</a> - Show the status of Git file changes as linemode in the file list.
+</summary>
+
+```bash
+ya pack -a yazi-rs/plugins:git
+```
+
+</details>
 
 <details>
 <summary>
@@ -632,19 +699,8 @@ git clone https://gitee.com/DreamMaoMao/git.yazi $env:APPDATA\yazi\config\plugin
 
 ```bash
 ya pack -a llanosrocas/githead
-````
-
-</details>
-
-<details>
-<summary>
-<a href="https://github.com/redbeardymcgee/yazi-plugins/tree/main/git-status.yazi">git-status.yazi</a> - git prompt plugin for Yazi.
-</summary>
-  
-```bash
-ya pack -a redbeardymcgee/yazi-plugins:git-status
-# Only for Yazi v0.2.5 or lesser, replacemenet is git.yazi
 ```
+
 </details>
 
 ### Preloader Images
@@ -653,10 +709,11 @@ ya pack -a redbeardymcgee/yazi-plugins:git-status
 <summary>
 <a href="https://github.com/Sonico98/allmytoes.yazi">allmytoes.yazi</a> - Preview freedesktop-compatible thumbnails using <a href="https://gitlab.com/allmytoes/allmytoes">allmytoes</a>.
 </summary>
-  
+
 ```bash
 ya pack -a Sonico98/allmytoes
 ```
+
 </details>
 
 ### Fetchers
@@ -665,17 +722,18 @@ ya pack -a Sonico98/allmytoes
 <summary>
 <a href="https://github.com/redbeardymcgee/yazi-plugins/tree/main/mime.yazi">mime.yazi</a> - Replace the builtin `mime` plugin to speed up the identification of large files by using file extensions instead of file content to obtain the mime-types.
 </summary>
-  
+
 ```bash
 # This is not needed for yazi v0.3.0 or later
 ya pack -a redbeardymcgee/yazi-plugins:mime
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://gitee.com/DreamMaoMao/mime-ext.yazi">DreamMaoMao/mime-ext.yazi</a> - A Yazi plugin that quickly get mimetype to improved theme rendering speed.</summary>
-  
+
 ```bash
 # Linux/macOS
 git clone https://gitee.com/DreamMaoMao/mime-ext.yazi.git ~/.config/yazi/plugins/mime-ext.yazi
@@ -684,7 +742,8 @@ git clone https://gitee.com/DreamMaoMao/mime-ext.yazi.git ~/.config/yazi/plugins
 
 git clone https://gitee.com/DreamMaoMao/mime-ext.yazi.git %AppData%\yazi\config\plugins\mime-ext.yazi
 
-````
+```
+
 </details>
 
 <details>
@@ -696,6 +755,7 @@ git clone https://gitee.com/DreamMaoMao/mime-ext.yazi.git %AppData%\yazi\config\
 # Linux
 git clone https://gitee.com/DreamMaoMao/mime-preview.yazi.git ~/.config/yazi/plugins/mime-preview.yazi
 ```
+
 </details>
 
 ### Neovim & Vim
@@ -709,6 +769,7 @@ git clone https://gitee.com/DreamMaoMao/mime-preview.yazi.git ~/.config/yazi/plu
 # packer.nvim
 use {'is0n/fm-nvim'}
 ```
+
 </details>
 
 <details>
@@ -756,7 +817,7 @@ show_help = '<f1>',
 
 -- For more information, check the repository.
 
-````
+```
 
 </details>
 
@@ -786,10 +847,11 @@ show_help = '<f1>',
 <summary>
 <a href="https://github.com/chriszarate/yazi.vim">yazi.vim</a> - Vim plugin for Yazi.
 </summary>
-  
+
 ```bash
 Plug 'chriszarate/yazi.vim'
 ```
+
 </details>
 
 ### Shell plugins
@@ -798,30 +860,33 @@ Plug 'chriszarate/yazi.vim'
 <summary>
 <a href="https://github.com/KKV9/command.yazi">command.yazi</a> - Display a prompt for executing yazi commands.
 </summary>
-  
+
 ```bash
 ya pack -a KKV9/command
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/AnirudhG07/custom-shell.yazi">custom-shell.yazi</a> - Set your custom-shell as your default yazi Shell.
 </summary>
-  
+
 ```bash
 ya pack -a AnirudhG07/custom-shell
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Sonico98/yazi-prompt.sh">yazi-prompt.sh</a> - Display an indicator in your prompt when running inside a yazi subshell.
 </summary>
-  
+
 ```bash
 ya pack -a Sonico98/yazi-prompt
 ```
+
 </details>
 
 ### Utilities
@@ -830,10 +895,11 @@ ya pack -a Sonico98/yazi-prompt
 <summary>
 <a href="https://github.com/lpnh/icons-brew.yazi">icons-brew.yazi</a> - Make a hot `theme.toml` for your Yazi icons with your favorite color palette.
 </summary>
-  
+
 ```bash
 ya pack -a lpnh/icons-brew
 ```
+
 </details>
 
 ## Flavors
@@ -842,40 +908,44 @@ ya pack -a lpnh/icons-brew
 <summary>
 <a href="https://github.com/yazi-rs/flavors/tree/main/catppuccin-frappe.yazi">catppuccin-frappe.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/flavors:catppuccin-mocha
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/flavors/tree/main/catppuccin-latte.yazi">catppuccin-latte.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/flavors:catppuccin-latte
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/flavors/tree/main/catppuccin-macchaito.yazi">catppuccin-macchiato.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/flavors:catppuccin-macchiato
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/yazi-rs/flavors/tree/main/catppuccin-mocha.yazi">catppuccin-mocha.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a yazi-rs/flavors:catppuccin-mocha
 ```
+
 </details>
 
 <details>
@@ -893,20 +963,22 @@ ya pack -a dangooddd/kanagawa
 <summary>
 <a href="https://github.com/BennyOe/onedark.yazi">onedark.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a BennyOe/onedark
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/BennyOe/tokyo-night.yazi">tokyo-night.yazi</a>
 </summary>
-  
+
 ```bash
 ya pack -a BennyOe/tokyo-night
 ```
+
 </details>
 
 ## Themes
@@ -915,63 +987,69 @@ ya pack -a BennyOe/tokyo-night
 <summary>
 <a href="https://github.com/catppuccin/yazi">Catppuccin</a>
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/sachinsenal0x64/crystal-theme.yazi">Crystal</a>
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/poperigby/gruvbox-dark-yazi">Gruvbox Dark</a>
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Reledia/flexoki.yazi">Flexoki</a>
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Mellbourn/ls-colors.yazi">LS_COLORS</a> - Adds over 300 different colors for filetypes (converted from <a href="https://github.com/trapd00r/LS_COLORS">the LS_COLORS collection</a> using <a href="https://github.com/Mellbourn/lsColorsToToml">lsColorsToToml</a>)
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 <details>
 <summary>
 <a href="https://github.com/Msouza91/rose-pine.yazi">Rosé Pine</a>
 </summary>
-  
+
 ```
 Manual Installation Required.
 ```
+
 </details>
 
 ## Community
 
-- [discord(English mainly)](https://discord.gg/qfADduSdJu)
-- [Telegram(Chinese mainly)](https://t.me/yazi_rs)
+- [Discord (English mainly)](https://discord.gg/qfADduSdJu)
+- [Telegram (Chinese mainly)](https://t.me/yazi_rs)


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/author_name/package.yazi">package.yazi</a> - A brief description about your package.
</summary>

```bash
# This contains downloading instruction, prefer `ya pack`, if not, git clone instruction will do.
ya pack -a author_name/package
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.


This PR also removed https://github.com/redbeardymcgee/yazi-plugins/tree/main/git-status.yazi because it was a duplicate of DreamMaoMao/git.yazi and has been archived

@AnirudhG07  Should we clean up other plugins from https://github.com/redbeardymcgee/yazi-plugins that are already archived?