### PR TITLE
add copy-file-contents.yazi to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,17 @@ ya pack -a hankertrix/augment-command
 
 <details>
 <summary>
+<a href="https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi">copy-file-contents.yazi</a> - A simple plugin to copy the contents of a file to the clipboard directly from yazi.
+</summary>
+
+```bash
+ya pack -a AnirudhG07/plugins-yazi:copy-file-contents
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/TD-Sky/sudo.yazi">sudo.yazi</a> - Call `sudo` in yazi.
 </summary>
 


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/author_name/package.yazi">package.yazi</a> - A brief description about your package.
</summary>

```bash
# This contains downloading instruction, prefer `ya pack`, if not, git clone instruction will do.
ya pack -a author_name/package
```

</details>

<br>

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [X] I have added my package in ascending order in the sub-section of chosen category.
- [X] I have added in the format mentioned above.
