### PR TITLE
docs(README): add macydnah/office.yazi previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ ya pack -a AnirudhG07/nbpreview
 
 <details>
 <summary>
+<a href="https://github.com/macydnah/office.yazi">office.yazi</a> - Office documents previewer plugin for Yazi, using <a href="https://www.libreoffice.org/about-us/who-are-we/">libreoffice</a> (compatible with .docx, .xlsx, .pptx, .odt, .ods, .odp; and other file formats supported by the Office Open XML and OpenDocument standards).
+</summary>
+
+```bash
+ya pack -a macydnah/office
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/ndtoan96/ouch.yazi">ouch.yazi</a> - An archive previewer plugin for Yazi, using <a href="https://github.com/ouch-org/ouch">ouch</a>.
 </summary>
 


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/macydnah/[office.yazi](https://github.com/macydnah/office.yazi)">office.yazi</a> - Office documents previewer plugin for Yazi, using <a href="https://www.[libreoffice](https://www.libreoffice.org/about-us/who-are-we/).org/about-us/who-are-we/">libreoffice</a> (compatible with .docx, .xlsx, .pptx, .odt, .ods, .odp; and other file formats supported by the Office Open XML and OpenDocument standards).
</summary>

```bash
ya pack -a macydnah/office
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
