### PR TITLE
Add path-from-root plugin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,17 @@ ya pack -a yazi-rs/plugins:vcs-files
 
 </details>
 
+<details>
+<summary>
+<a href="https://github.com/aresler/path-from-root.yazi">path-from-root.yazi</a> - Copy file path relative to Git root.
+</summary>
+
+```bash
+ya pack -a aresler/path-from-root
+```
+
+</details>
+
 ### Preloader Images
 
 <details>


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/author_name/package.yazi">package.yazi</a> - A brief description about your package.
</summary>

```bash
# This contains downloading instruction, prefer `ya pack`, if not, git clone instruction will do.
ya pack -a author_name/package
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
