### PR TITLE
Added duckdb.yazi to previewers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ ya pack -a gesellkammer/audio-preview
 
 <details>
 <summary>
+<a href="https://github.com/wylie102/duckdb.yazi">duckdb.yazi</a> - Preview csv, tsv, json, and Parquet files using <a href="duckdb](https://github.com/duckdb/duckdb">duckdb</a>. View the raw data, or a compact summarized view of columns.
+</summary>
+
+```bash
+ya pack -a wylie102/duckdb
+```
+
+
+</details>
+
+<details>
+<summary>
 <a href="https://gitee.com/DreamMaoMao/epub.yazi">epub.yazi</a> - Plugin for Yazi to preview epub file.
 </summary>
 


### PR DESCRIPTION
Added duckdb.yazi to previewers in the format below.

<details>
<summary>
<a href="https://github.com/wylie102/duckdb.yazi">duckdb.yazi</a> - Preview csv, tsv, json, and Parquet files using <a href="duckdb](https://github.com/duckdb/duckdb">duckdb</a>. View the raw data, or a compact summarized view of columns.
</summary>

```bash
ya pack -a wylie102/duckdb
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
