### PR TITLE
Added telegram-send.yazi to File Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,18 @@ ya pack -a boydaihungst/simple-mtpfs
 
 <details>
 <summary>
+<a href="https://github.com/pareix/telegram-send.yazi">telegram-send.yazi</a> - Send files via telegram-send directly inside Yazi
+</summary>
+
+```bash
+# Requirements: telegram-send python library
+ya pack -a pareix/telegram-send
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/boydaihungst/thunar-bulk-rename.yazi">thunar-bulk-rename.yazi</a> - Bulk rename using thunar -B in Linux.
 </summary>
 


### PR DESCRIPTION
I added telegram-send.yazi in the format below.

<details>
<summary>
<a href="https://github.com/pareix/telegram-send.yazi">telegram-send.yazi</a> - Send files via telegram-send directly inside Yazi
</summary>

```bash
# Requirements: telegram-send python library
ya pack -a pareix/telegram-send
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
