### PR TITLE
add hwp-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ ya pkg add Reledia/hexyl
 
 <details>
 <summary>
+<a href="https://github.com/beskep/hwp-preview.yazi">hwp-preview.yazi</a> - HWP/HWPX file previewer for Hancom Hangul, the dominant word processor in Korea.
+</summary>
+
+```bash
+ya pkg add beskep/hwp-preview
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/lsar.yazi">lsar.yazi</a> - Previewing archive contents with lsar.
 </summary>
 


### PR DESCRIPTION
Add hwp-preview, a HWP/HWPX file previewer for Hancom Hangul, the dominant word processor in Korea.

---

Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/author_name/package.yazi">package.yazi</a> - A brief description about your package.
</summary>

```bash
# This contains downloading instruction, prefer `ya pack`, if not, git clone instruction will do.
ya pkg add author_name/package
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
