### PR TITLE
Add Dupes plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,17 @@ ya pkg add yazi-rs/plugins:diff
 
 <details>
 <summary>
+<a href="https://github.com/mshnwq/dupes.yazi">dupes.yazi</a> - Duplicate files plugin for Yazi using `jdupes`.
+</summary>
+
+```bash
+ya pkg add mshnwq/dupes
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/BBOOXX/file-actions.yazi">file-actions.yazi</a> - A Yazi plugin that allows users to perform actions on selected files using custom scripts.
 </summary>
 


### PR DESCRIPTION
Added details for dupes.yazi plugin.

Thanks for creating your package and adding in awesome-yazi.
Please add your package in the following format to allow users to access your plugin as well as to increase ease to download them.

<details>
<summary>
<a href="https://github.com/author_name/package.yazi">package.yazi</a> - A brief description about your package.
</summary>

```bash
# This contains downloading instruction, prefer `ya pack`, if not, git clone instruction will do.
ya pkg add author_name/package
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
