### PR TITLE
Add doclayer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,6 +1637,17 @@ ya pkg add yazi-rs/plugins:types
 
 </details>
 
+<details>
+<summary>
+<a href="https://github.com/doclayer/yazi-doclayer">doclayer.yazi</a> - AI-powered document intelligence - upload, extract, and search documents with pre-built agents for contracts, invoices, and compliance.
+</summary>
+
+```bash
+ya pkg add doclayer/yazi-doclayer
+```
+
+</details>
+
 - [yazi_types.lua](https://github.com/hankertrix/augment-command.yazi/blob/main/yazi_types.lua) - A type file containing most of Yazi's Lua API.
 
 ## Flavors


### PR DESCRIPTION
## Plugin: doclayer

**Repository**: https://github.com/doclayer/yazi-doclayer

### Description

Doclayer turns Yazi into a document intelligence hub. Upload PDFs, contracts, and invoices directly from Yazi and get structured AI extractions.

### Features

- Upload documents with AI extraction
- Batch process entire directories
- Semantic search across documents
- Pre-built agents for contracts, invoices, compliance
- Per-directory configuration via .doclayer.yaml

### Commands

| Keys | Action |
|------|--------|
| D u | Upload file with AI extraction |
| D b | Batch upload directory |
| D s | Semantic search |
| D a | Browse extraction agents |

### Requirements

- Yazi v0.2.0+
- doclayer-cli (pip install doclayer-cli)
- Doclayer account

### Checklist

- [x] Plugin has a clear README
- [x] Plugin license clearly stated (MIT)
- [x] Repository is publicly accessible
- [x] Plugin works with latest Yazi version