### PR TITLE
Added faster-piper.yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ ya pkg add yazi-rs/plugins:piper
 
 <details>
 <summary>
+<a href="https://github.com/alberti42/faster-piper.yazi">faster-piper.yazi</a> - Pipe any shell command as a cached previewer. Drop-in replacement for <a href="https://github.com/yazi-rs/plugins/tree/main/piper.yazi">piper.yazi</a>, optimized for speed and precision.
+</summary>
+
+```bash
+ya pkg add alberti42/faster-piper
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/AminurAlam/yazi-plugins/blob/main/preview-audio.yazi">preview-audio.yazi</a> - Preview cover art and metadata of audio files.
 </summary>
 


### PR DESCRIPTION
<details>
<summary>
<a href="https://github.com/alberti42/faster-piper.yazi">faster-piper.yazi</a> - A fast, cache-aware rewrite of `piper` plugin for Yazi. It provides a general-purpose previewer that pipes the output of an arbitrary shell command into Yazi’s preview pane, with aggressive caching and efficient scrolling for large outputs. 
</summary>

```bash
# This contains downloading instruction, prefer `ya pkg`, if not, git clone instruction will do.
ya pkg add alberti42/faster-piper
```

</details>

<br>

- [X] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [X] I have added my package in ascending order in the sub-section of chosen category.
- [X] I have added in the format mentioned above.
