### PR TITLE
Add mesh-preview.yazi to previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ ya pkg add boydaihungst/mediainfo
 
 <details>
 <summary>
+<a href="https://github.com/dimi1357/mesh-preview.yazi">mesh-preview.yazi</a> - Preview 3D mesh files and point clouds using <a href="https://trimesh.org/">trimesh</a> and <a href="https://matplotlib.org/">matplotlib</a>.
+</summary>
+
+```bash
+ya pkg add dimi1357/mesh-preview
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/Reledia/miller.yazi">miller.yazi</a> - Preview CSV files (and other supported formats) using <a href="https://github.com/johnkerl/miller">miller</a>.
 </summary>
 


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.

Adding [mesh-preview.yazi](https://github.com/dimi1357/mesh-preview.yazi) - A Yazi plugin to preview 3D mesh files and point clouds using trimesh and matplotlib.

<details>
<summary>
<a href="https://github.com/dimi1357/mesh-preview.yazi">mesh-preview.yazi</a> - Preview 3D mesh files and point clouds using <a href="https://trimesh.org/">trimesh</a> and <a href="https://matplotlib.org/">matplotlib</a>.
</summary>

```bash
ya pkg add dimi1357/mesh-preview
```

</details>

### Features
- Preview 3D meshes (OBJ, STL, PLY, GLTF, GLB, FBX, etc.) with shaded rendering
- Support for point clouds with height-based coloring
- Automatic mesh simplification for large files

---

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.