### PR TITLE
Add pickle.yazi to previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ ya pkg add yazi-rs/plugins:piper
 
 <details>
 <summary>
+<a href="https://github.com/dimi1357/pickle.yazi">pickle.yazi</a> - Preview Python pickle (.pkl, .pickle) files with pretty-printed contents.
+</summary>
+
+```bash
+ya pkg add dimi1357/pickle
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/AminurAlam/yazi-plugins/blob/main/preview-audio.yazi">preview-audio.yazi</a> - Preview cover art and metadata of audio files.
 </summary>
 


### PR DESCRIPTION
Thanks for creating your package and adding in awesome-yazi.

Adding [pickle.yazi](https://github.com/dimi1357/pickle.yazi) - A Yazi plugin to preview Python pickle files in the terminal.

<details>
<summary>
<a href="https://github.com/dimi1357/pickle.yazi">pickle.yazi</a> - Preview Python pickle (.pkl, .pickle) files with pretty-printed contents.
</summary>

```bash
ya pkg add dimi1357/pickle
```

</details>

### Features
- Pretty-printed preview of pickle file contents
- Shows data type information
- Scrollable preview for large data structures
- No external dependencies (uses Python's built-in modules)

---

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.