### PR TITLE
Add symlink-target-path.yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,8 +879,6 @@ ya pkg add uhs-robert/sshfs.yazi
 
 ```bash
 ya pkg add vmikk/symlink-target-path
-# To configure, add the following to your `~/.config/yazi/keymap.toml`:
-#     { on = [ "c", "t" ], run = "plugin symlink-target-path", desc = "Copy symlink target paths" }, 
 ```
 
 </details>


### PR DESCRIPTION
Hi!

<details>
<summary>
<a href="https://github.com/vmikk/symlink-target-path.yazi">symlink-target-path.yazi</a> - Copy the resolved target path of symlinks. Configurable: disable path normalization and skip broken links.
</summary>

```bash
ya pkg add vmikk/symlink-target-path
# To configure, add the following to your `~/.config/yazi/keymap.toml`:
#     { on = [ "c", "t" ], run = "plugin symlink-target-path", desc = "Copy symlink target paths" }, 
```

</details>
<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
