### PR TITLE
Add mesh-preview.yazi Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ ya pkg add boydaihungst/mediainfo
 
 <details>
 <summary>
+<a href="https://github.com/dimi1357/mesh-preview.yazi">mesh-preview.yazi</a> - Preview 3D mesh files and point clouds in the terminal.
+</summary>
+
+```bash
+ya pkg add dimi1357/mesh-preview
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/Reledia/miller.yazi">miller.yazi</a> - Preview CSV files (and other supported formats) using <a href="https://github.com/johnkerl/miller">miller</a>.
 </summary>
 


### PR DESCRIPTION
## Summary
- Added mesh-preview.yazi to the Previewers section
- Plugin enables terminal-based previewing of 3D mesh files and point clouds
- Supports 10 different 3D file formats: OBJ, STL, PLY, glTF, GLB, FBX, 3DS, DAE, OFF, and VTK
- Placed alphabetically between mediainfo.yazi and miller.yazi

## Repository
https://github.com/dimi1357/mesh-preview.yazi

## Key Features
- Rendering 3D meshes with shading effects
- Displaying point clouds with height-based color mapping
- Automatic simplification of large mesh files
- Fast rendering powered by matplotlib

Generated with [Claude Code](https://claude.com/claude-code)