### PR TITLE
Add pickle.yazi Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ ya pkg add ndtoan96/ouch
 
 <details>
 <summary>
+<a href="https://github.com/dimi1357/pickle.yazi">pickle.yazi</a> - Preview Python pickle files in the terminal.
+</summary>
+
+```bash
+ya pkg add dimi1357/pickle
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/piper.yazi">piper.yazi</a> - Pipe any shell command as a previewer.
 </summary>
 


### PR DESCRIPTION
## Summary
- Added pickle.yazi to the Previewers section
- Plugin enables preview of Python pickle files (.pkl and .pickle) in the terminal
- Provides pretty-printed preview with data type information
- Scrollable interface for large data structures
- Placed alphabetically between ouch.yazi and piper.yazi

## Repository
https://github.com/dimi1357/pickle.yazi

## Key Features
- Pretty-printed preview of pickle file contents
- Data type information display
- Scrollable interface for large data structures
- No external dependencies beyond Python 3's built-in modules

Generated with [Claude Code](https://claude.com/claude-code)