### PR TITLE
Add mermaid.yazi to Previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ ya pkg add boydaihungst/mediainfo
 
 <details>
 <summary>
+<a href="https://github.com/passion0102/mermaid.yazi">mermaid.yazi</a> - Render <a href="https://mermaid.js.org/">Mermaid</a> diagrams inline in Markdown previews. Uses <a href="https://mermaid.ink">mermaid.ink</a> by default and falls back to <a href="https://github.com/mermaid-js/mermaid-cli">mermaid-cli</a> for offline rendering. Composes glow-rendered text with the mermaid image and supports a mode toggle (split / image / text) plus image-area zoom.
+</summary>
+
+```bash
+ya pkg add passion0102/mermaid
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/dimi1357/mesh-preview.yazi">mesh-preview.yazi</a> - Preview 3D mesh files and point clouds in the terminal.
 </summary>
 


### PR DESCRIPTION
Adds [passion0102/mermaid.yazi](https://github.com/passion0102/mermaid.yazi) to the **Previewers** section, alphabetically between `mediainfo.yazi` and `mesh-preview.yazi`.

## What it does

Renders [Mermaid](https://mermaid.js.org/) diagrams inline in Markdown previews. The split-mode previewer composes glow-rendered Markdown text with a mermaid image (fetched from [mermaid.ink](https://mermaid.ink) by default, or rendered locally via [mermaid-cli](https://github.com/mermaid-js/mermaid-cli) for offline / air-gapped setups). Also supports a mode toggle (split / image / text) and image-area zoom via keymap entries.

Screenshot in the plugin's README: https://github.com/passion0102/mermaid.yazi#readme

## Checklist

- [x] Plugin builds and runs against the latest yazi (26.1.4)
- [x] Installed via `ya pkg add passion0102/mermaid`
- [x] README documents requirements, installation, configuration, error reference
- [x] Alphabetical ordering preserved in the Previewers list