### PR TITLE
Add age-badge.yazi to UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1451,6 +1451,17 @@ ya pkg add grappas/wl-clipboard
 
 <details>
 <summary>
+<a href="https://github.com/alchezar/age-badge.yazi">age-badge.yazi</a> - A color-coded badge showing each file's age, from red (recent) to violet (old). Inspired by OneCommander.
+</summary>
+
+```bash
+ya pkg add alchezar/age-badge
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/josephschmitt/auto-layout.yazi">auto-layout.yazi</a> - Automatically change number of columns based on available width.
 </summary>
 


### PR DESCRIPTION
Adds [age-badge.yazi](https://github.com/alchezar/age-badge.yazi) to the **UI enhancements** section.

It shows a small color-coded chip next to each file indicating how long ago it was modified - the hue runs from red (just modified) through the spectrum to violet (long ago), inspired by the age column in [OneCommander](https://onecommander.com/). Installable via `ya pkg add alchezar/age-badge`.

Entry is placed alphabetically at the top of the section.

## Checklist

- [x] Plugin builds and runs against the latest yazi (26.5.6)
- [x] Installed via `ya pkg add terrakok/split-tabs`
- [x] README documents requirements, installation, configuration, error reference
- [x] Alphabetical ordering preserved in the UI enhancements list