### PR TITLE
Add split-tabs.yazi to UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,17 @@ ya pkg add dawsers/dual-pane
 
 <details>
 <summary>
+<a href="https://github.com/terrakok/split-tabs.yazi">split-tabs.yazi</a> - Provides a dual-pane view by splitting the screen between two tabs.
+</summary>
+
+```bash
+ya pkg add terrakok/split-tabs
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/grimandgreedy/ffmpeg-stats.yazi">ffmpeg-stats.yazi</a> - Display audio and video information in yazi's linemode.
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,17 @@ ya pkg add Ape/simple-status
 
 <details>
 <summary>
+<a href="https://github.com/terrakok/split-tabs.yazi">split-tabs.yazi</a> - Provides a dual-pane view by splitting the screen between two tabs.
+</summary>
+
+```bash
+ya pkg add terrakok/split-tabs
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/Rolv-Apneseth/starship.yazi">starship.yazi</a> - Starship prompt plugin for Yazi.
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -1484,17 +1484,6 @@ ya pkg add dawsers/dual-pane
 
 <details>
 <summary>
-<a href="https://github.com/terrakok/split-tabs.yazi">split-tabs.yazi</a> - Provides a dual-pane view by splitting the screen between two tabs.
-</summary>
-
-```bash
-ya pkg add terrakok/split-tabs
-```
-
-</details>
-
-<details>
-<summary>
 <a href="https://github.com/grimandgreedy/ffmpeg-stats.yazi">ffmpeg-stats.yazi</a> - Display audio and video information in yazi's linemode.
 </summary>
 


### PR DESCRIPTION
Adds [terrakok/split-tabs.yazi](https://github.com/terrakok/split-tabs.yazi) to the **UI enhancements** section, alphabetically between `simple-status.yazi` and `starship.yazi`.

## What it does
A [Yazi](https://github.com/sxyazi/yazi) plugin that provides a dual-pane view by splitting the screen between two tabs.
<img width="1300" height="1012" alt="image" src="https://github.com/user-attachments/assets/bd36e4c3-9c00-4a70-92e4-9bd934aed052" />

## Checklist

- [x] Plugin builds and runs against the latest yazi (26.5.6)
- [x] Installed via `ya pkg add terrakok/split-tabs`
- [x] README documents requirements, installation, configuration, error reference
- [x] Alphabetical ordering preserved in the UI enhancements list
