### PR TITLE
Add hxjump

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,21 @@ ya pkg add pakhromov/goto-file-dir
 
 <details>
 <summary>
+<a href="https://tangled.org/ivelieu.quietism.art/hxjump.yazi">hxjump.yazi</a> - Helix-like two character jump to any visible file or folder
+</summary>
+
+```bash
+# Linux/macOS
+git clone https://tangled.org/ivelieu.quietism.art/hxjump.yazi ~/.config/yazi/plugins/hxjump.yazi
+
+# Windows
+git clone https://tangled.org/ivelieu.quietism.art/hxjump.yazi %AppData%\yazi\config\plugins\hxjump.yazi
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi">jump-to-char.yazi</a> - Vim-like `f<char>`, jump to the next file whose name starts with `<char>`.
 </summary>
 


### PR DESCRIPTION
I'm putting down a `git clone` command because I don't think `ya pkg add` can work for non-github repos yet.

<details>
<summary>
<a href="https://tangled.org/ivelieu.quietism.art/hxjump.yazi">hxjump.yazi</a> - Helix-like two character jump to any visible file or folder
</summary>

```bash
git clone https://tangled.org/ivelieu.quietism.art/hxjump.yazi ~/.config/yazi/plugins/hxjump.yazi
```

</details>


<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
