### PR TITLE
Add vscode-git-colors, vscode-git-gutter, mobile-auto-layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,17 @@ ya pkg add ryanda/video-grid
 
 <details>
 <summary>
+<a href="https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-gutter.yazi">vscode-git-gutter.yazi</a> - Preview text and code with syntax highlighting, line numbers, and a VS Code style git change gutter.
+</summary>
+
+```bash
+ya pkg add ShikherVerma/yazi-plugins:vscode-git-gutter
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/pakhromov/xcursor-preview.yazi">xcursor-preview.yazi</a> - Preview xcursor files with metadata and frame-by-frame animation scrolling.
 </summary>
 
@@ -1565,6 +1576,17 @@ ya pkg add yazi-rs/plugins:no-status
 
 <details>
 <summary>
+<a href="https://github.com/ShikherVerma/yazi-plugins/tree/main/mobile-auto-layout.yazi">mobile-auto-layout.yazi</a> - Adapt column widths to content and screen size, with a reading mode that widens the preview, built for phone-narrow terminals.
+</summary>
+
+```bash
+ya pkg add ShikherVerma/yazi-plugins:mobile-auto-layout
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/saumyajyoti/omp.yazi">omp.yazi</a> - oh-my-posh prompt plugin for Yazi.
 </summary>
 
@@ -1753,6 +1775,17 @@ ya pkg add Lil-Dank/lazygit
 
 ```bash
 ya pkg add yazi-rs/plugins:vcs-files
+```
+
+</details>
+
+<details>
+<summary>
+<a href="https://github.com/ShikherVerma/yazi-plugins/tree/main/vscode-git-colors.yazi">vscode-git-colors.yazi</a> - Color file names by their git status, VS Code style, with status letters for files and dot badges for directories in every column.
+</summary>
+
+```bash
+ya pkg add ShikherVerma/yazi-plugins:vscode-git-colors
 ```
 
 </details>


### PR DESCRIPTION
Three yazi plugins, built and tested against yazi 26.5.6.

- vscode-git-colors: VS Code style git status colors and badges on file names, in every column.
- vscode-git-gutter: VS Code style change gutter in the text preview, scrolls instantly.
- mobile-auto-layout: columns size themselves to their content and your screen. Scrolling the preview flips to a near fullscreen reading mode; built for phone terminals, comfortable on laptops.

![git colors](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/git-colors.png)

changes are shown in the gutter margin like vscode

![change gutter](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/git-gutter.png)

mobile-auto-layout on a laptop, browse and reading mode:

Browse mode:
![browse on laptop](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/auto-layout-browse.png)

Reading mode collapses a panel so the preview panel shows up with more width:
![reading on laptop](https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/auto-layout-reading.png)

And on a phone:

on phone only two panels are shown
<img src="https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/phone-browse.png" width="320">

in reading mode the preview panel takes up most of the width
<img src="https://raw.githubusercontent.com/ShikherVerma/yazi-plugins/main/screenshots/phone-portrait.png" width="320">
