### PR TITLE
Add yazi-album-plugin.yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,19 @@ ya pkg add nsavvide/duck-radar
 
 </details>
 
+<details>
+<summary>
+<a href="https://github.com/bmcszk/yazi-album-plugin">yazi-album-plugin.yazi</a> - Upload selected photos to a cloud album via <a href="https://rclone.org/">rclone</a> through a 3-step fzf wizard (provider → remote → album; existing or create-new).
+</summary>
+
+
+```bash
+ya pkg add bmcszk/yazi-album-plugin
+```
+
+
+</details>
+
 ### Filter Enhancements
 
 <details>


### PR DESCRIPTION
## What

A yazi plugin that uploads selected photos to a cloud album via [rclone](https://rclone.org/) through a 3-step fzf wizard: pick **provider** → pick **remote** → pick **album** (existing **or** type a new name). Per-file progress + final summary.

- Repo: https://github.com/bmcszk/yazi-album-plugin
- License: MIT
- Install: `ya pkg add bmcszk/yazi-album-plugin`

## Category

File Actions (upload/transfer — sits alongside `rsync.yazi`, `telegram-send.yazi`, `gvfs.yazi`).

## Why

rclone supports 60+ cloud backends (Google Photos, Drive, Dropbox, S3, Immich via local, …) but there was no yazi plugin that let you **pick the target album interactively at upload time**. This fills that gap with an explicit wizard (no hardcoded remote/album).

## Checklist

- [x] Entry uses the standard `<details>/<summary>` format with `ya pkg add`
- [x] Plugin repo is public and `ya pkg add bmcszk/yazi-album-plugin` works
- [x] Follows existing entry style in the File Actions section