### PR TITLE
Add red-table.yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,18 @@ ya pkg add uhs-robert/recycle-bin.yazi
 
 <details>
 <summary>
+<a href="https://github.com/volker-schukai/red-table/tree/main/red-table.yazi">red-table.yazi</a> - Select images visually in red-table and return the confirmed selection to Yazi.
+</summary>
+
+```bash
+# Requirements: red-table, Unix, Yazi >= 26.5.6
+ya pkg add volker-schukai/red-table:red-table
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/Ape/reflink.yazi">reflink.yazi</a> - Create reflinks to files.
 </summary>
 


### PR DESCRIPTION
Adds `red-table.yazi` to the File Actions section. The plugin launches
red-table as a visual image selector and replaces Yazi's selection only after
confirmation.

The package command was verified against the public 0.2.0 release:

    ya pkg add volker-schukai/red-table:red-table

- [x] I have read the CONTRIBUTING.md file.
- [x] I have added my package in ascending order in the chosen subsection.
- [x] I have added it in the requested details and installation format.
