### PR TITLE
Add encapsulate.yazi to File Actions Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,17 @@ ya pkg add mshnwq/dupes
 
 <details>
 <summary>
+<a href="https://github.com/lesliek-dev/encapsulate.yazi">encapsulate.yazi</a> - Move individual selected files into their own self-named directories.
+</summary>
+
+```bash
+ya pkg add lesliek-dev/encapsulate
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/BBOOXX/file-actions.yazi">file-actions.yazi</a> - A Yazi plugin that allows users to perform actions on selected files using custom scripts.
 </summary>
 


### PR DESCRIPTION
Adds [encapsulate.yazi](https://github.com/lesliek-dev/encapsulate.yazi), a basic plugin I made to move a file into a self-named directory on a keybind. Figured I'd put it in here in-case others have the same workflow. 

<br>

- [X] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [X] I have added my package in ascending order in the sub-section of chosen category.
- [X] I have added in the format mentioned above.
