### PR TITLE
Add dsh-tui.yazi to Shell Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2042,6 +2042,17 @@ ya pkg add AnirudhG07/custom-shell
 
 <details>
 <summary>
+<a href="https://github.com/tr1v3r/dsh-tui.yazi">dsh-tui.yazi</a> - Launch dsh-TUI with explicitly selected Yazi files appended to an editable prompt.
+</summary>
+
+```bash
+ya pkg add tr1v3r/dsh-tui
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/Tyarel8/nu.yazi">nu.yazi</a> - A plugin for yazi to execute `nu` code.
 </summary>
 


### PR DESCRIPTION
Adds `dsh-tui.yazi` to the Shell Plugins section. The entry is alphabetized between `custom-shell.yazi` and `nu.yazi` and uses the documented `ya pkg` installation command.

<details>
<summary>
<a href="https://github.com/tr1v3r/dsh-tui.yazi">dsh-tui.yazi</a> - Launch dsh-TUI with explicitly selected Yazi files appended to an editable prompt.
</summary>

```bash
ya pkg add tr1v3r/dsh-tui
```

</details>

<br>

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
