### PR TITLE
Add recents.yazi to File Actions Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,17 @@ ya pkg add lmnek/pandoc
 
 <details>
 <summary>
+<a href="https://github.com/nmetschke/recents.yazi">recents.yazi</a> - Recently used files using the <a href="https://www.freedesktop.org/wiki/Specifications/desktop-bookmark-spec">desktop-bookmark-spec</a> (Linux only), supporting viewing, adding and removing.
+</summary>
+
+```bash
+ya pkg add nmetschke/recents
+```
+
+</details>
+
+<details>
+<summary>
 <a href="https://github.com/uhs-robert/recycle-bin.yazi">recycle-bin.yazi</a> - Manage your Trash from Yazi: browse contents, restore or delete selected items, empty by age, or empty completely using trash-cli.
 </summary>
 


### PR DESCRIPTION
Adds [recents.yazi](https://github.com/nmetschke/recents.yazi), a plugin I wrote to show recently used files in a VFS. It's based on the [freedesktop desktop-bookmark-spec](https://www.freedesktop.org/wiki/Specifications/desktop-bookmark-spec). Currently, it supports viewing, adding and removing/updating entries from the `recently-used.xbel` file.

- [x] I have read the [CONTRIBUTING.md](https://github.com/AnirudhG07/awesome-yazi/blob/main/CONTRIBUTING.md) file.
- [x] I have added my package in ascending order in the sub-section of chosen category.
- [x] I have added in the format mentioned above.
